### PR TITLE
動画リストの表示速度の高速化

### DIFF
--- a/NicoPlayerHohoema/Models/Settings/NGSettings.cs
+++ b/NicoPlayerHohoema/Models/Settings/NGSettings.cs
@@ -39,9 +39,6 @@ namespace NicoPlayerHohoema.Models
 			result = IsNgVideoOwnerId(info.OwnerId.ToString());
 			if (result != null) return result;
 
-			result = IsNGVideoId(info.RawVideoId);
-			if (result != null) return result;
-
 			result = IsNGVideoTitle(info.Title);
 			if (result != null) return result;
 
@@ -91,6 +88,8 @@ namespace NicoPlayerHohoema.Models
 
 		public NGResult IsNGVideoTitle(string title)
 		{
+            if (string.IsNullOrEmpty(title)) { return null; }
+
 			if (this.NGVideoTitleKeywordEnable && this.NGVideoTitleKeywords.Count > 0)
 			{
                 var ngItem = this.NGVideoTitleKeywords.FirstOrDefault(x => x.CheckNG(title));

--- a/NicoPlayerHohoema/Models/Video/NicoVideo.cs
+++ b/NicoPlayerHohoema/Models/Video/NicoVideo.cs
@@ -49,7 +49,11 @@ namespace NicoPlayerHohoema.Models
 
         public CommentClient CommentClient { get; private set; }
 
-		public NicoVideo(HohoemaApp app, string rawVideoid, NiconicoMediaManager manager)
+
+        public bool IsThumbnailInitialized => _thumbnailInitialized;
+
+
+        public NicoVideo(HohoemaApp app, string rawVideoid, NiconicoMediaManager manager)
 		{
 			HohoemaApp = app;
 			RawVideoId = rawVideoid;

--- a/NicoPlayerHohoema/ViewModels/CacheManagementPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/CacheManagementPageViewModel.cs
@@ -144,7 +144,7 @@ namespace NicoPlayerHohoema.ViewModels
 
 
 
-        public override uint OneTimeLoadCount => (uint)RawList.Count;
+        public override uint OneTimeLoadCount => (uint)10;
 
         public CacheVideoInfoLoadingSource(HohoemaApp app, PageManager pageManager)
             : base(app, nameof(CacheManagementPageViewModel))
@@ -175,7 +175,7 @@ namespace NicoPlayerHohoema.ViewModels
 
             foreach (var item in mediaManager.CacheVideos.ToArray())
             {
-                if (item.GetAllQuality().ToArray().Any(x => x.IsCacheRequested))
+                if (item.GetAllQuality().Any(x => x.IsCacheRequested))
                 {
                     list.Add(item);
                 }

--- a/NicoPlayerHohoema/ViewModels/CommunityVideoPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/CommunityVideoPageViewModel.cs
@@ -149,7 +149,7 @@ namespace NicoPlayerHohoema.ViewModels
 
 		#region Implements HohoemaPreloadingIncrementalSourceBase		
 
-		public override uint OneTimeLoadCount => 20; // RSSの一回のページアイテム数が18個なので、表示スピード考えてその半分
+		public override uint OneTimeLoadCount => 9; // RSSの一回のページアイテム数が18個なので、表示スピード考えてその半分
 
 		protected override Task<int> ResetSourceImpl()
 		{

--- a/NicoPlayerHohoema/ViewModels/HistoryPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/HistoryPageViewModel.cs
@@ -167,23 +167,27 @@ namespace NicoPlayerHohoema.ViewModels
 		{
 			get
 			{
-				return 100;
+				return 10;
 			}
 		}
         protected override async Task<int> HohoemaPreloadingResetSourceImpl()
         {
+            await Task.Delay(0);
+
             if (_HistoriesResponse == null) { return 0; }
 
             HistriesItems = await HohoemaApp.MediaManager.GetNicoVideoItemsAsync(
-                _HistoriesResponse.Histories.Select(x => x.ItemId).ToArray()
-                );
-
+               _HistoriesResponse.Histories.Select(x => x.ItemId).ToArray()
+               );
             return _HistoriesResponse.Histories.Count;
         }
 
         protected override HistoryVideoInfoControlViewModel NicoVideoToTemplatedItem(NicoVideo sourceNicoVideos, int index)
         {
-            var watchCount = _HistoriesResponse.Histories.Single(x => x.ItemId == sourceNicoVideos.RawVideoId).WatchCount;
+            var history = _HistoriesResponse.Histories[index];
+            var watchCount = history.WatchCount;
+
+            sourceNicoVideos.PreSetTitle(history.Title);
 
             return new HistoryVideoInfoControlViewModel(
                     watchCount
@@ -197,6 +201,7 @@ namespace NicoPlayerHohoema.ViewModels
         protected override async Task<IEnumerable<NicoVideo>> PreloadNicoVideo(int start, int count)
         {
             await Task.Delay(0);
+
             return HistriesItems.Skip(start).Take(count);
         }
 

--- a/NicoPlayerHohoema/ViewModels/RankingCategoryPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/RankingCategoryPageViewModel.cs
@@ -231,7 +231,7 @@ namespace NicoPlayerHohoema.ViewModels
 
         #region Implements HohoemaPreloadingIncrementalSourceBase		
 
-        public override uint OneTimeLoadCount => 25;
+        public override uint OneTimeLoadCount => 15;
 
         protected override async Task<IEnumerable<NicoVideo>> PreloadNicoVideo(int start, int count)
 		{
@@ -261,12 +261,12 @@ namespace NicoPlayerHohoema.ViewModels
 
                 for (var index = 0; index < Videos.Count; ++index)
                 {
-                    var item = items.ElementAt(index);
-                    var nicoVideo = Videos.ElementAt(index);
+                    var item = items[index];
+                    var nicoVideo = Videos[index];
 
-                    var title = RankingRankPrefixPatternRegex.Replace(item.Title, "");
+//                    var title = RankingRankPrefixPatternRegex.Replace(item.Title, "");
 
-                    nicoVideo.PreSetTitle(title);
+//                    nicoVideo.PreSetTitle(item.Title);
                     //					nicoVideo.PreSetPostAt(DateTime.Parse(item.PubDate));
                 }
             }

--- a/NicoPlayerHohoema/ViewModels/SearchResultPage/SearchResultCommunityPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/SearchResultPage/SearchResultCommunityPageViewModel.cs
@@ -82,7 +82,7 @@ namespace NicoPlayerHohoema.ViewModels
 
 	public class CommunitySearchSource : IIncrementalSource<CommunityInfoControlViewModel>
 	{
-		public uint OneTimeLoadCount => 20;
+		public uint OneTimeLoadCount => 10;
 
 		public HohoemaApp HohoemaApp { get; private set; }
 		public PageManager PageManager { get; private set; }

--- a/NicoPlayerHohoema/ViewModels/UserVideoPageViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/UserVideoPageViewModel.cs
@@ -131,8 +131,6 @@ namespace NicoPlayerHohoema.ViewModels
 			_ResList = new List<UserVideoResponse>();
 		}
 
-        public override uint OneTimeLoadCount => 8;
-
         #region Implements HohoemaPreloadingIncrementalSourceBase		
 
         protected override async Task<IEnumerable<NicoVideo>> PreloadNicoVideo(int start, int count)
@@ -185,7 +183,7 @@ namespace NicoPlayerHohoema.ViewModels
 			, int index
 			)
 		{
-			return new VideoInfoControlViewModel(itemSource, PageManager);
+			return new VideoInfoControlViewModel(itemSource, PageManager, isNgEnabled:false);
 		}
 
 		#endregion

--- a/NicoPlayerHohoema/ViewModels/VideoInfoControlViewModel.cs
+++ b/NicoPlayerHohoema/ViewModels/VideoInfoControlViewModel.cs
@@ -42,8 +42,6 @@ namespace NicoPlayerHohoema.ViewModels
         public VideoInfoControlViewModel(MylistData data, NicoVideo nicoVideo, PageManager pageManager)
 			: this(nicoVideo, pageManager)
 		{
-			Title = data.Title;
-			RawVideoId = data.ItemId;
             OptionText = data.CreateTime.ToString();
             if (!string.IsNullOrWhiteSpace(data.ThumbnailUrl.OriginalString))
             {
@@ -56,8 +54,6 @@ namespace NicoPlayerHohoema.ViewModels
             }
 
 			ImageCaption = data.Length.ToString(); // TODO: ユーザーフレンドリィ時間
-
-			VideoId = RawVideoId;
 		}
 
 
@@ -65,9 +61,6 @@ namespace NicoPlayerHohoema.ViewModels
 		public VideoInfoControlViewModel(VideoInfo data, NicoVideo nicoVideo, PageManager pageManager)
 			: this(nicoVideo, pageManager)
 		{
-            
-            Title = data.Video.Title;
-            RawVideoId = data.Video.Id;
             OptionText = data.Video.UploadTime.ToString();
             if (!string.IsNullOrWhiteSpace(data.Video.ThumbnailUrl.OriginalString))
             {
@@ -80,8 +73,6 @@ namespace NicoPlayerHohoema.ViewModels
             }
 
             ImageCaption = data.Video.Length.ToString(); // TODO: ユーザーフレンドリィ時間
-
-            VideoId = RawVideoId;
         }
 
         bool _IsNGEnabled = false;
@@ -95,10 +86,6 @@ namespace NicoPlayerHohoema.ViewModels
             _CompositeDisposable = new CompositeDisposable();
 
             _IsNGEnabled = isNgEnabled;
-
-            Title = nicoVideo.Title;
-			RawVideoId = nicoVideo.RawVideoId;
-			VideoId = nicoVideo.VideoId;
 
             if (nicoVideo.IsDeleted)
             {
@@ -166,6 +153,13 @@ namespace NicoPlayerHohoema.ViewModels
 
         public void SetupFromThumbnail(NicoVideo info)
         {
+            if (!info.IsThumbnailInitialized)
+            {
+                return;
+            }
+
+            RaisePropertyChanged(nameof(Title));
+
             // NG判定
             if (_IsNGEnabled)
             {
@@ -178,7 +172,6 @@ namespace NicoPlayerHohoema.ViewModels
                 }
             }
 
-            Title = info.Title;
             OptionText = info.PostedAt.ToString("yyyy/MM/dd HH:mm");
             if (!string.IsNullOrWhiteSpace(info.ThumbnailUrl))
             {
@@ -224,11 +217,11 @@ namespace NicoPlayerHohoema.ViewModels
 			};
 		}
 
-       
-		
-		public string VideoId { get; private set; }
 
-		public string RawVideoId { get; private set; }
+
+        public string VideoId => NicoVideo.VideoId;
+
+        public string RawVideoId => NicoVideo.RawVideoId;
 
         public VideoStatus VideoStatus { get; private set; }
 
@@ -545,9 +538,6 @@ namespace NicoPlayerHohoema.ViewModels
 
 
         public bool IsXbox => Util.DeviceTypeHelper.IsXbox;
-
-        public ReadOnlyReactiveProperty<bool> IsPlayed { get; private set; }
-
         
         public IEnumerable<VideoInfoPlaylistViewModel> Playlists => 
             HohoemaPlaylist.Playlists.Select(x => new VideoInfoPlaylistViewModel(x.Name, x.Id, NicoVideo));
@@ -567,6 +557,9 @@ namespace NicoPlayerHohoema.ViewModels
 		public NicoVideo NicoVideo { get; private set; }
         public HohoemaPlaylist HohoemaPlaylist { get; private set; }
         public PageManager PageManager { get; private set; }
+
+
+        public new string Title => NicoVideo.Title;
 	}
 
 


### PR DESCRIPTION
see at #525

サムネイル読み込み前にNGチェックなどを行っていた部分をカットして、動画リストの表示開始までに掛かる時間を高速化しています。

