### PR TITLE
#404 フォローの読み込みに非同期ロックを導入

### DIFF
--- a/NicoPlayerHohoema/Models/Follow/FollowInfoGroup/FollowInfoGroupBase.cs
+++ b/NicoPlayerHohoema/Models/Follow/FollowInfoGroup/FollowInfoGroupBase.cs
@@ -1,4 +1,5 @@
 ﻿using Mntone.Nico2;
+using NicoPlayerHohoema.Util;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -14,11 +15,13 @@ namespace NicoPlayerHohoema.Models
 
 		protected ObservableCollection<FollowItemInfo> _FollowInfoList;
 
+        protected AsyncLock UpdateLock { get; } = new AsyncLock();
 
 
-		#endregion
 
-		public ReadOnlyObservableCollection<FollowItemInfo> FollowInfoItems { get; private set; }
+        #endregion
+
+        public ReadOnlyObservableCollection<FollowItemInfo> FollowInfoItems { get; private set; }
 
 		public HohoemaApp HohoemaApp { get; private set; }
 
@@ -46,7 +49,15 @@ namespace NicoPlayerHohoema.Models
 		protected abstract Task<ContentManageResult> RemoveFollow_Internal(string id, object token = null);
 
 
-		public abstract Task Sync();
+		protected abstract Task SyncFollowItems_Internal();
+
+        public async Task SyncFollowItems()
+        {
+            using (var releaser = await UpdateLock.LockAsync())
+            {
+                await SyncFollowItems_Internal();
+            }
+        }
 
 
 		public bool IsFollowItem(string id)

--- a/NicoPlayerHohoema/Models/Follow/FollowInfoGroup/FollowInfoGroupBaseTemplate.cs
+++ b/NicoPlayerHohoema/Models/Follow/FollowInfoGroup/FollowInfoGroupBaseTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using Mntone.Nico2;
+using NicoPlayerHohoema.Util;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -24,34 +25,34 @@ namespace NicoPlayerHohoema.Models
 		
 
 
-		public override async Task Sync()
+		protected override async Task SyncFollowItems_Internal()
 		{
-			var userFavDatas = await GetFollowSource();
+            var userFavDatas = await GetFollowSource();
 
-			// まだローカルデータとして登録されていないIDを追加分として抽出
-			var addedItems = userFavDatas
-				.Where(x =>
-				{
-					var itemId = FollowSourceToItemId(x);
-					return _FollowInfoList.All(y => y.Id != itemId);
-				})
-				.Select(ConvertToFollowInfo);
+            // まだローカルデータとして登録されていないIDを追加分として抽出
+            var addedItems = userFavDatas
+                .Where(x =>
+                {
+                    var itemId = FollowSourceToItemId(x);
+                    return _FollowInfoList.All(y => y.Id != itemId);
+                })
+                .Select(ConvertToFollowInfo);
 
-			foreach (var addItem in addedItems)
-			{
-				_FollowInfoList.Add(addItem);
-			}
+            foreach (var addItem in addedItems)
+            {
+                _FollowInfoList.Add(addItem);
+            }
 
 
-			// オンラインデータから削除されているアイテムを抽出
-			var itemIds = userFavDatas.Select(FollowSourceToItemId).ToArray();
-			var removedItems = _FollowInfoList
-				.Where(x => !itemIds.Any(y => x.Id == y))
-				.ToList();
-			foreach (var removeItem in removedItems)
-			{
-				_FollowInfoList.Remove(removeItem);
-			}
+            // オンラインデータから削除されているアイテムを抽出
+            var itemIds = userFavDatas.Select(FollowSourceToItemId).ToArray();
+            var removedItems = _FollowInfoList
+                .Where(x => !itemIds.Any(y => x.Id == y))
+                .ToList();
+            foreach (var removeItem in removedItems)
+            {
+                _FollowInfoList.Remove(removeItem);
+            }
 		}
 
 

--- a/NicoPlayerHohoema/Models/Follow/IFollowInfoGroup.cs
+++ b/NicoPlayerHohoema/Models/Follow/IFollowInfoGroup.cs
@@ -17,7 +17,7 @@ namespace NicoPlayerHohoema.Models
 		bool CanMoreAddFollow();
 		bool IsFollowItem(string id);
 
-		Task Sync();
+		Task SyncFollowItems();
 
 
 		Task<ContentManageResult> AddFollow(string name, string id, object token = null);

--- a/NicoPlayerHohoema/Views/FollowManagePage.xaml
+++ b/NicoPlayerHohoema/Views/FollowManagePage.xaml
@@ -54,6 +54,20 @@
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
+
+
+            <!-- 読み込み中 -->
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{Binding NowUpdatingFavList.Value}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="LoadingProgressBar.IsIndeterminate" Value="True" />
+                        <Setter Target="LoadingProgressBar.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
         
@@ -91,6 +105,13 @@
             <ScrollViewer x:Name="ScrollList"
                       >
                 <StackPanel Margin="16 16 16 16">
+
+                    <ProgressBar IsIndeterminate="False"
+                                 x:Name="LoadingProgressBar"
+                                 Visibility="Collapsed"
+                                 Height="8"
+                                 HorizontalAlignment="Stretch"
+                                 />
                     <Pivot ItemsSource="{Binding Lists}" x:Name="FavListContainer"
                                   >
 
@@ -123,7 +144,7 @@
                                                             Margin="8 0"
                                                         >
                                             <Run Text="登録数：" />
-                                            <Run Text="{Binding ItemCount}" />
+                                            <Run Text="{Binding ItemCount.Value}" />
                                             <Run Text="/" />
                                             <Run Text="{Binding MaxItemCount}" />
                                         </TextBlock>


### PR DESCRIPTION
#404 への対応です。

フォローの読み込み中に非同期の参照エラーがあったと記憶しているため、非同期ロックを導入しています。

設定→「アプリのUI」からフォローのページをスタートアップに設定した上での確認もして、正常動作を確認しています。