### PR TITLE
Show TitleBarMarginLayout in tablet mode (not only in desktop mode)

### DIFF
--- a/NicoPlayerHohoema/Views/Player/VideoPlayerPage.xaml
+++ b/NicoPlayerHohoema/Views/Player/VideoPlayerPage.xaml
@@ -835,7 +835,6 @@
                         <logicalTrigger:MultiTrigger>
                             <logicalTrigger:MultiTrigger.Triggers>
                                 <hardTrigger:DeviceFamilyTrigger Condition="Desktop" />
-                                <intractionTrigger:InteractionModeTrigger Condition="Mouse" />
                             </logicalTrigger:MultiTrigger.Triggers>
                         </logicalTrigger:MultiTrigger>
                     </VisualState.StateTriggers>


### PR DESCRIPTION
So the buttons at the top will not be overlapped by titlebar area in tablet mode. 
(A lazy workaround for #775 )