### PR TITLE
検索結果を検索ポータルページ内に統合して表示する

### DIFF
--- a/Hohoema/App.xaml.cs
+++ b/Hohoema/App.xaml.cs
@@ -370,7 +370,7 @@ namespace Hohoema
 
                 Type[] migrateTypes = new Type[]
                 {
-                    typeof(DatabaseMigrate_0_25_0)
+                    typeof(DatabaseMigrate_0_25_0),
                 };
 
                 
@@ -399,7 +399,11 @@ namespace Hohoema
                 
                 Container.Resolve<MigrationCommentFilteringSettings>().Migration();
                 Container.Resolve<CommentFilteringNGScoreZeroFixture>().Migration();
+
                 await Task.Run(async () => { await Container.Resolve<SettingsMigration_V_0_23_0>().MigrateAsync(); });
+
+                Container.Resolve<SearchPageQueryMigrate_0_26_0>().Migrate();
+
 
                 // 機能切り替え管理クラスをDIコンテナに登録
                 // Xaml側で扱いやすくするためApp.xaml上でインスタンス生成させている

--- a/Hohoema/Hohoema.csproj
+++ b/Hohoema/Hohoema.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>ja-JP</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Hohoema/Hohoema.csproj
+++ b/Hohoema/Hohoema.csproj
@@ -137,6 +137,7 @@
     </Compile>
     <Compile Include="Models.Domain\Application\FeatureFlags.cs" />
     <Compile Include="Models.Domain\Niconico\UserFeature\NicoRepoItemTopic.cs" />
+    <Compile Include="Models.UseCase\Migration\SearchPageQueryMigrate_0_26_0.cs" />
     <Compile Include="Presentation.ViewModels.Pages\UserPages\UserInfoViewModel.cs" />
     <Compile Include="Presentation.ViewModels.Pages\VideoListPage\Commands\MylistCopyItemCommand.cs" />
     <Compile Include="Presentation.ViewModels.Pages\VideoListPage\Commands\MylistMoveItemCommand.cs" />

--- a/Hohoema/Locales/ja-JP.txt
+++ b/Hohoema/Locales/ja-JP.txt
@@ -598,6 +598,11 @@ HiddenThisRankingGenre = このジャンルを隠す
 
 
 #### Search ####
+VideoSearchSuggest = 動画検索
+LiveSearchSuggest = 生放送検索
+DetailSearchSuggest = 詳細検索
+
+
 SearchTarget.Keyword = キーワード
 SearchTarget.Tag = タグ
 SearchTarget.Mylist = マイリスト

--- a/Hohoema/Locales/zh-CHS.txt
+++ b/Hohoema/Locales/zh-CHS.txt
@@ -598,6 +598,11 @@ HiddenThisRankingGenre = 隐藏此类型
 
 
 #### Search ####
+VideoSearchSuggest = 影片搜寻
+LiveSearchSuggest = 直播搜索
+DetailSearchSuggest = 详细搜索
+
+
 SearchTarget.Keyword = 关键字
 SearchTarget.Tag = 标签
 SearchTarget.Mylist = Mylist

--- a/Hohoema/Models.Domain/Application/AppFlagsRepository.cs
+++ b/Hohoema/Models.Domain/Application/AppFlagsRepository.cs
@@ -60,5 +60,11 @@ namespace Hohoema.Models.Domain.Application
             set => Save(value);
         }
 
+
+        public bool IsSearchQueryInPinsMigration_V_0_26_0
+        {
+            get => Read<bool>();
+            set => Save(value);
+        }
     }
 }

--- a/Hohoema/Models.Domain/PageNavigation/HohoemaPageType.cs
+++ b/Hohoema/Models.Domain/PageNavigation/HohoemaPageType.cs
@@ -18,10 +18,15 @@ namespace Hohoema.Models.Domain.PageNavigation
 		Search,
         SearchSummary,
 
+        [Obsolete]
         SearchResultCommunity,
+        [Obsolete]
         SearchResultTag,
+        [Obsolete]
         SearchResultKeyword,
+        [Obsolete]
         SearchResultMylist,
+        [Obsolete]
         SearchResultLive,
 
 		FeedGroupManage,

--- a/Hohoema/Models.UseCase/Migration/SearchPageQueryMigrate_0_26_0.cs
+++ b/Hohoema/Models.UseCase/Migration/SearchPageQueryMigrate_0_26_0.cs
@@ -1,0 +1,69 @@
+﻿using Hohoema.Models.Domain.Application;
+using Hohoema.Models.Domain.PageNavigation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hohoema.Models.UseCase.Migration
+{
+    public class SearchPageQueryMigrate_0_26_0 : IMigrate
+    {
+        private readonly AppFlagsRepository _appFlagsRepository;
+        private readonly PinSettings _pinSettings;
+
+        public SearchPageQueryMigrate_0_26_0(
+            AppFlagsRepository appFlagsRepository,
+            PinSettings pinSettings
+            )
+        {
+            _appFlagsRepository = appFlagsRepository;
+            _pinSettings = pinSettings;
+        }
+
+        public void Migrate()
+        {
+            if (_appFlagsRepository.IsSearchQueryInPinsMigration_V_0_26_0) { return; }
+
+            var pins = _pinSettings.ReadAllItems();
+            foreach (var pin in pins)
+            {
+#pragma warning disable CS0612 // 型またはメンバーが旧型式です
+                if (pin.PageType == Domain.PageNavigation.HohoemaPageType.SearchResultKeyword)
+                {
+                    pin.PageType = Domain.PageNavigation.HohoemaPageType.Search;
+                    pin.Parameter = pin.Parameter + $"&service={SearchTarget.Keyword}";
+                    _pinSettings.UpdateItem(pin);
+                }
+                else if (pin.PageType == Domain.PageNavigation.HohoemaPageType.SearchResultTag)
+                {
+                    pin.PageType = Domain.PageNavigation.HohoemaPageType.Search;
+                    pin.Parameter = pin.Parameter + $"&service={SearchTarget.Tag}";
+                    _pinSettings.UpdateItem(pin);
+                }
+                else if (pin.PageType == Domain.PageNavigation.HohoemaPageType.SearchResultMylist)
+                {
+                    pin.PageType = Domain.PageNavigation.HohoemaPageType.Search;
+                    pin.Parameter = pin.Parameter + $"&service={SearchTarget.Mylist}";
+                    _pinSettings.UpdateItem(pin);
+                }
+                else if (pin.PageType == Domain.PageNavigation.HohoemaPageType.SearchResultLive)
+                {
+                    pin.PageType = Domain.PageNavigation.HohoemaPageType.Search;
+                    pin.Parameter = pin.Parameter + $"&service={SearchTarget.Niconama}";
+                    _pinSettings.UpdateItem(pin);
+                }
+                else if (pin.PageType == Domain.PageNavigation.HohoemaPageType.SearchResultCommunity)
+                {
+                    pin.PageType = Domain.PageNavigation.HohoemaPageType.Search;
+                    pin.Parameter = pin.Parameter + $"&service={SearchTarget.Community}";
+                    _pinSettings.UpdateItem(pin);
+                }
+#pragma warning restore CS0612 // 型またはメンバーが旧型式です
+            }
+
+            _appFlagsRepository.IsSearchQueryInPinsMigration_V_0_26_0 = true;
+        }
+    }
+}

--- a/Hohoema/Presentation.Services/Page/PageManagerSearchExtention.cs
+++ b/Hohoema/Presentation.Services/Page/PageManagerSearchExtention.cs
@@ -16,35 +16,13 @@ namespace Hohoema.Presentation.Services.Page
     {
         public static void Search(this PageManager pageManager, SearchTarget target, string keyword, bool forgetLastSearch = false)
         {
-            HohoemaPageType resultPageType = HohoemaPageType.Search;
-            switch (target)
-            {
-                case SearchTarget.Keyword:
-                    resultPageType = HohoemaPageType.SearchResultKeyword;
-                    break;
-                case SearchTarget.Tag:
-                    resultPageType = HohoemaPageType.SearchResultTag;
-                    break;
-                case SearchTarget.Niconama:
-                    resultPageType = HohoemaPageType.SearchResultLive;
-                    break;
-                case SearchTarget.Mylist:
-                    resultPageType = HohoemaPageType.SearchResultMylist;
-                    break;
-                case SearchTarget.Community:
-                    resultPageType = HohoemaPageType.SearchResultCommunity;
-                    break;
-                default:
-                    break;
-            }
-
             var p = new NavigationParameters
             {
                 { "keyword", System.Net.WebUtility.UrlEncode(keyword) },
-                { "target", resultPageType }
+                { "service", target }
             };
 
-            pageManager.OpenPage(resultPageType, p, forgetLastSearch ? NavigationStackBehavior.NotRemember : NavigationStackBehavior.Push);
+            pageManager.OpenPage(HohoemaPageType.Search, p, forgetLastSearch ? NavigationStackBehavior.NotRemember : NavigationStackBehavior.Push);
         }
         /*
         public static void SearchKeyword(this PageManager pageManager, string content, bool isForgetNavigation = false)

--- a/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchPageViewModel.cs
+++ b/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchPageViewModel.cs
@@ -26,10 +26,11 @@ using Hohoema.Models.Domain.Niconico.Search;
 using Hohoema.Models.Domain.PageNavigation;
 using Hohoema.Presentation.ViewModels.VideoListPage;
 using Prism.Navigation;
+using I18NPortable;
 
 namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
 {
-    public class SearchPageViewModel : HohoemaViewModelBase
+    public class SearchPageViewModel : HohoemaViewModelBase, ITitleUpdatablePage, IPinablePage
     {
 
 		public ApplicationLayoutManager ApplicationLayoutManager { get; }
@@ -277,7 +278,24 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
 			base.OnNavigatedTo(parameters);
         }
 
-	}
+        public IObservable<string> GetTitleObservable()
+        {
+			return Observable.Empty<string>();
+			return SearchText.Select(x => x);
+        }
+
+        public HohoemaPin GetPin()
+        {
+			if (_LastKeyword == null) { return null; }
+			
+			return new HohoemaPin()
+			{
+				Label = _LastKeyword + $" - {_LastSelectedTarget.Translate()}",
+				PageType = HohoemaPageType.Search,
+				Parameter = $"keyword={System.Net.WebUtility.UrlEncode(_LastKeyword)}&service={SelectedTarget.Value}",
+			};
+        }
+    }
 
 
 

--- a/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultKeywordPageViewModel.cs
+++ b/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultKeywordPageViewModel.cs
@@ -286,7 +286,7 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
 
         protected override IIncrementalSource<VideoInfoControlViewModel> GenerateIncrementalSource()
 		{
-            return new VideoSearchSource(SearchOption.Keyword, SearchOption.SearchTarget == SearchTarget.Tag, SearchOption.Sort, SearchOption.Order, SearchProvider);
+            return new VideoSearchSource(SearchOption.Keyword, false, SearchOption.Sort, SearchOption.Order, SearchProvider);
 		}
 
 		protected override void PostResetList()

--- a/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultKeywordPageViewModel.cs
+++ b/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultKeywordPageViewModel.cs
@@ -237,13 +237,11 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
             get { return _SearchOptionText; }
             set { SetProperty(ref _SearchOptionText, value); }
         }
-        
+
+        #region Commands
 
 
-		#region Commands
-
-
-		private DelegateCommand _ShowSearchHistoryCommand;
+        private DelegateCommand _ShowSearchHistoryCommand;
         private readonly SearchHistoryRepository _searchHistoryRepository;
 
         public DelegateCommand ShowSearchHistoryCommand
@@ -288,7 +286,7 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
 
         protected override IIncrementalSource<VideoInfoControlViewModel> GenerateIncrementalSource()
 		{
-            return new VideoSearchSource(SearchOption, SearchProvider);
+            return new VideoSearchSource(SearchOption.Keyword, SearchOption.SearchTarget == SearchTarget.Tag, SearchOption.Sort, SearchOption.Order, SearchProvider);
 		}
 
 		protected override void PostResetList()
@@ -305,5 +303,12 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
         }
         #endregion
 
+    }    
+
+
+    public enum VideoSearchMode
+    {
+        Keyword,
+        Tag
     }
 }

--- a/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultTagPageViewModel.cs
+++ b/Hohoema/Presentation.ViewModels.Pages/SearchPages/SearchResultTagPageViewModel.cs
@@ -320,8 +320,8 @@ namespace Hohoema.Presentation.ViewModels.Pages.SearchPages
 
         protected override IIncrementalSource<VideoInfoControlViewModel> GenerateIncrementalSource()
 		{
-			return new VideoSearchSource(SearchOption, SearchProvider);
-		}
+            return new VideoSearchSource(SearchOption.Keyword, SearchOption.SearchTarget == SearchTarget.Tag, SearchOption.Sort, SearchOption.Order, SearchProvider);
+        }
 
 		
 		protected override bool CheckNeedUpdateOnNavigateTo(NavigationMode mode)

--- a/Hohoema/Presentation.ViewModels/Navigation.Commands/SearchCommand.cs
+++ b/Hohoema/Presentation.ViewModels/Navigation.Commands/SearchCommand.cs
@@ -35,10 +35,10 @@ namespace Hohoema.Presentation.ViewModels.Navigation.Commands
 
             if (parameter is string text)
             {
-                var searched = _searchHistoryRepository.LastSearchedTarget(text);
-                SearchTarget searchType = searched ?? SearchTarget.Keyword;
+//                var searched = _searchHistoryRepository.LastSearchedTarget(text);
+//                SearchTarget searchType = searched ?? SearchTarget.Keyword;
 
-                _pageManager.Search(searchType, text);
+                _pageManager.Search(SearchTarget.Keyword, text);
             }
         }
     }

--- a/Hohoema/Presentation.ViewModels/PrimaryWindowCoreLayoutViewModel.cs
+++ b/Hohoema/Presentation.ViewModels/PrimaryWindowCoreLayoutViewModel.cs
@@ -106,6 +106,25 @@ namespace Hohoema.Presentation.ViewModels
                     Task.Run(() => { SettingsRestoredTempraryFlags.Instance.WhenPinsRestored(); });
                     
                 });
+
+            SearchAutoSuggestItems = new ObservableCollection<SearchAutoSuggestItemViewModel>
+            {
+                new SearchAutoSuggestItemViewModel()
+                {
+                    Id = "VideoSearchSuggest",
+                    SearchAction = (s) => PageManager.Search(SearchTarget.Keyword, s),
+                },
+                new SearchAutoSuggestItemViewModel()
+                {
+                    Id = "LiveSearchSuggest",
+                    SearchAction = (s) => PageManager.Search(SearchTarget.Niconama, s),
+                },
+                new SearchAutoSuggestItemViewModel()
+                {
+                    Id = "DetailSearchSuggest",
+                    SearchAction = (s) => PageManager.OpenPage(HohoemaPageType.Search, ""),
+                },
+            };
         }
 
         public IEventAggregator EventAggregator { get; }
@@ -129,6 +148,7 @@ namespace Hohoema.Presentation.ViewModels
 
         public ObservableCollection<HohoemaPin> Pins { get; }
 
+        public ObservableCollection<SearchAutoSuggestItemViewModel> SearchAutoSuggestItems { get; set; }
 
         // call from PrimaryWindowsCoreLayout.xaml.cs
         public void AddPin(HohoemaPin pin)
@@ -213,8 +233,29 @@ namespace Hohoema.Presentation.ViewModels
             pin.OverrideLabel = string.IsNullOrEmpty(result) ? null : result;
             PinSettings.UpdateItem(pin);
         }
+
+
+
+
+        #region Search
+
+        private DelegateCommand<SearchAutoSuggestItemViewModel> _SuggestSelectedCommand;
+        public DelegateCommand<SearchAutoSuggestItemViewModel> SuggestSelectedCommand =>
+            _SuggestSelectedCommand ?? (_SuggestSelectedCommand = new DelegateCommand<SearchAutoSuggestItemViewModel>(ExecuteSuggestSelectedCommand));
+
+        void ExecuteSuggestSelectedCommand(SearchAutoSuggestItemViewModel parameter)
+        {
+
+        }
+
+        #endregion
     }
 
+    public sealed class SearchAutoSuggestItemViewModel
+    {
+        public string Id { get; set; }
+        public Action<string> SearchAction { get; set; }
+    }
 
     
 

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml
@@ -140,7 +140,7 @@
             </windowsStateTriggers:EqualsStateTrigger>
           </VisualState.StateTriggers>
           <VisualState.Setters>
-            <Setter Target="ContentLayout.Margin" Value="0 32 0 0" />
+            <Setter Target="ContentLayout.Margin" Value="0 0 0 0" />
             <Setter Target="ContentLayout.Padding" Value="{StaticResource ContentPageMargin_Desktop}" />
             <Setter Target="SearchTargetListView.Margin" Value="120 8 0 8" />
           </VisualState.Setters>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml
@@ -17,97 +17,12 @@
     xmlns:hardTrigger="using:AdaptiveTriggerLibrary.Triggers.HardwareInterfaceTriggers"
     xmlns:uwpControls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:uwpextensions="using:Microsoft.Toolkit.Uwp.UI.Extensions"
-    xmlns:templateSelector="using:Hohoema.Presentation.Views.TemplateSelector" xmlns:windowsStateTriggers="using:WindowsStateTriggers" DataContext="{x:Null}"
+    xmlns:templateSelector="using:Hohoema.Presentation.Views.TemplateSelector" 
+  xmlns:windowsStateTriggers="using:WindowsStateTriggers" xmlns:appModels="using:Hohoema.Models.Domain.Application"
+  DataContext="{x:Null}"
+  NavigationCacheMode="Required"
     mc:Ignorable="d">
   <Page.Resources>
-    <DataTemplate x:Key="VideoSearchTargetTemplate">
-      <ListView ItemsSource="{Binding VideoSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-        <ListView.ItemContainerStyle>
-          <Style TargetType="ListViewItem">
-            <Setter Property="Width" Value="180" />
-          </Style>
-        </ListView.ItemContainerStyle>
-        <ListView.ItemsPanel>
-          <ItemsPanelTemplate>
-            <ItemsWrapGrid Orientation="Horizontal" />
-          </ItemsPanelTemplate>
-        </ListView.ItemsPanel>
-      </ListView>
-    </DataTemplate>
-    <DataTemplate x:Key="MylistSearchTargetTemplate">
-      <ListView ItemsSource="{Binding MylistSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-        <ListView.ItemContainerStyle>
-          <Style TargetType="ListViewItem">
-            <Setter Property="Width" Value="180" />
-          </Style>
-        </ListView.ItemContainerStyle>
-        <ListView.ItemsPanel>
-          <ItemsPanelTemplate>
-            <ItemsWrapGrid Orientation="Horizontal" />
-          </ItemsPanelTemplate>
-        </ListView.ItemsPanel>
-      </ListView>
-    </DataTemplate>
-    <DataTemplate x:Key="CommunitySearchTargetTemplate">
-      <StackPanel>
-        <ListView ItemsSource="{Binding CommunitySearchSortOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-          <ListView.ItemContainerStyle>
-            <Style TargetType="ListViewItem">
-              <Setter Property="Width" Value="180" />
-            </Style>
-          </ListView.ItemContainerStyle>
-          <ListView.ItemsPanel>
-            <ItemsPanelTemplate>
-              <ItemsWrapGrid Orientation="Horizontal" />
-            </ItemsPanelTemplate>
-          </ListView.ItemsPanel>
-        </ListView>
-        <ListView ItemsSource="{Binding CommunitySearchModeOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchMode.Value, Mode=TwoWay}" Margin="0 0 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-          <ListView.ItemsPanel>
-            <ItemsPanelTemplate>
-              <ItemsWrapGrid Orientation="Horizontal" />
-            </ItemsPanelTemplate>
-          </ListView.ItemsPanel>
-        </ListView>
-      </StackPanel>
-    </DataTemplate>
-    <DataTemplate x:Key="LiveVideoSearchTargetTemplate">
-      <StackPanel>
-        <!--
-                <ListView ItemsSource="{Binding LiveSearchSortOptionListItems}"
-                                  DisplayMemberPath="Label"
-                                  SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}"
-                                  Margin="0"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Center"
-                                  SelectionMode="Single"
-                          SingleSelectionFollowsFocus="False"
-                              >
-                    <ListView.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <ItemsWrapGrid Orientation="Horizontal" />
-                        </ItemsPanelTemplate>
-                    </ListView.ItemsPanel>
-
-                </ListView>
-                -->
-        <ListView ItemsSource="{Binding LiveSearchModeOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchMode.Value, Mode=TwoWay}" Margin="0 0 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-          <ListView.ItemsPanel>
-            <ItemsPanelTemplate>
-              <ItemsWrapGrid Orientation="Horizontal" />
-            </ItemsPanelTemplate>
-          </ListView.ItemsPanel>
-        </ListView>
-        <ListView ItemsSource="{Binding LiveSearchProviderOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedProvider.Value, Mode=TwoWay}" Margin="0 0 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-          <ListView.ItemsPanel>
-            <ItemsPanelTemplate>
-              <ItemsWrapGrid Orientation="Horizontal" />
-            </ItemsPanelTemplate>
-          </ListView.ItemsPanel>
-        </ListView>
-      </StackPanel>
-    </DataTemplate>
-    <templateSelector:SearchTargetContentTemplateSelector x:Key="SearchTargetContentTemplateSelector" Video="{StaticResource VideoSearchTargetTemplate}" Mylist="{StaticResource MylistSearchTargetTemplate}" Community="{StaticResource CommunitySearchTargetTemplate}" LiveVideo="{StaticResource LiveVideoSearchTargetTemplate}" />
     <DataTemplate x:Key="SearchHistoryItemTemplate">
       <toolkit:DockPanel Margin="0">
         <TextBlock Text="{Binding Keyword}" TextWrapping="Wrap" />
@@ -117,15 +32,23 @@
   <Grid>
     
     <Border>
-      <Grid Margin="0 16 0 0">
-        <toolkit:DockPanel Margin="16 8" x:Name="ContentLayout">
-          <Border Height="{Binding ElementName=HeaderLayout, Path=ActualHeight, Mode=OneWay}" toolkit:DockPanel.Dock="Top" />
+      <Grid Margin="0 0 0 0" MaxWidth="960">
+        <toolkit:DockPanel Margin="0 24 0 0" x:Name="ContentLayout">
           <toolkit:DockPanel Margin="0" toolkit:DockPanel.Dock="Top">
             <!-- ターゲット（Keyword, Tag etc） -->
-            <Border Margin="0 0 16 0" toolkit:DockPanel.Dock="Top">
-              <ListView ItemsSource="{Binding TargetListItems}" SelectedItem="{Binding SelectedTarget.Value, Mode=TwoWay}" HorizontalAlignment="Stretch" TabIndex="1" IsTabStop="True" UseSystemFocusVisuals="True" IsSynchronizedWithCurrentItem="False"
+            <Border Margin="0 0" toolkit:DockPanel.Dock="Top">
+              <ListView x:Name="SearchTargetListView" ItemsSource="{Binding TargetListItems}" SelectedItem="{Binding SelectedTarget.Value, Mode=TwoWay}" 
+                        HorizontalAlignment="Stretch" TabIndex="1" IsTabStop="True" UseSystemFocusVisuals="True" 
                         SingleSelectionFollowsFocus="False"
+                        SelectionMode="Single"
+                        Margin="120 8 0 8"
+                        IsItemClickEnabled="True"
                         >
+                <i:Interaction.Behaviors>
+                  <core:EventTriggerBehavior EventName="ItemClick">
+                    <core:InvokeCommandAction Command="{Binding DoSearchCommand}" />
+                  </core:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
                 <ListView.ItemTemplate>
                   <DataTemplate>
                     <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
@@ -139,47 +62,55 @@
               </ListView>
             </Border>
             <!-- 検索 -->
-            <StackPanel>
-              <toolkit:DockPanel>
-                <Button Margin="0 0 0 0" Command="{Binding DoSearchCommand}" Width="96" Height="48" toolkit:DockPanel.Dock="Right" UseSystemFocusVisuals="True">
-                  <StackPanel Orientation="Horizontal">
-                    <SymbolIcon Symbol="Find" />
-                  </StackPanel>
-                </Button>
-                <TextBox Text="{Binding SearchText.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ext:TextBoxFocusExtensions.AutoSelectOnFocus="True" VerticalAlignment="Stretch" InputScope="Search" x:Name="SearchTextBox" Margin="0 0 0 0" Height="48" FontSize="18" Style="{StaticResource BGTransparentTextBoxStyle}">
-                  <i:Interaction.Behaviors>
-                    <mybehavior:KeyboardTrigger Key="Enter">
-                      <mybehavior:KeyboardTrigger.Actions>
-                        <core:InvokeCommandAction Command="{Binding DoSearchCommand}" />
-                        <mybehavior:HideInputPaneAction />
-                      </mybehavior:KeyboardTrigger.Actions>
-                    </mybehavior:KeyboardTrigger>
-                  </i:Interaction.Behaviors>
-                </TextBox>
-              </toolkit:DockPanel>
-              <!-- 検索オプション -->
-              <uwpControls:Expander Content="{Binding SearchOptionVM.Value}" ContentTemplateSelector="{StaticResource SearchTargetContentTemplateSelector}" Header="検索オプション" toolkit:DockPanel.Dock="Bottom" Margin="0 8 0 0" HorizontalContentAlignment="Left"></uwpControls:Expander>
-            </StackPanel>
+            <toolkit:DockPanel Margin="0 0 0 8">
+              <DropDownButton toolkit:DockPanel.Dock="Right"
+                              Margin="0 0 8 0"
+                              Height="48"
+                              Width="64"
+                              >
+                <DropDownButton.Content>
+                  <SymbolIcon Symbol="Clock" />
+                </DropDownButton.Content>
+                <DropDownButton.Flyout>
+                  <Flyout>
+                    <ListView ItemsSource="{Binding SearchHistoryItems}" DisplayMemberPath="Keyword"
+                              SelectionMode="None"
+                              IsItemClickEnabled="True"
+                              >
+                      <i:Interaction.Behaviors>
+                        <core:EventTriggerBehavior EventName="ItemClick">
+                          <core:InvokeCommandAction Command="{Binding SearchHistoryItemCommand}" InputConverter="{StaticResource ItemClickEventArgsConverter}" />
+                        </core:EventTriggerBehavior>
+                      </i:Interaction.Behaviors>
+
+                    </ListView>
+                  </Flyout>
+                </DropDownButton.Flyout>
+              </DropDownButton>
+              
+              <Button Margin="8 0" Command="{Binding DoSearchCommand}" Width="80" Height="48" toolkit:DockPanel.Dock="Right" UseSystemFocusVisuals="True">
+                <StackPanel Orientation="Horizontal">
+                  <SymbolIcon Symbol="Find" />
+                </StackPanel>
+              </Button>
+
+              <TextBox Text="{Binding SearchText.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ext:TextBoxFocusExtensions.AutoSelectOnFocus="True" VerticalAlignment="Stretch" InputScope="Search" x:Name="SearchTextBox" Margin="0 0 0 0" Height="48" FontSize="18" Style="{StaticResource BGTransparentTextBoxStyle}">
+                <i:Interaction.Behaviors>
+                  <mybehavior:KeyboardTrigger Key="Enter">
+                    <mybehavior:KeyboardTrigger.Actions>
+                      <core:InvokeCommandAction Command="{Binding DoSearchCommand}" />
+                      <mybehavior:HideInputPaneAction />
+                    </mybehavior:KeyboardTrigger.Actions>
+                  </mybehavior:KeyboardTrigger>
+                </i:Interaction.Behaviors>
+              </TextBox>
+            </toolkit:DockPanel>
           </toolkit:DockPanel>
-          <TextBlock Text="{Binding Source=SearchHistory, Converter={StaticResource LocalizeConverter}}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0 24 0 8" toolkit:DockPanel.Dock="Top"></TextBlock>
-          <ListView ItemsSource="{Binding SearchHistoryItems}"
-                    ItemTemplate="{StaticResource SearchHistoryItemTemplate}"
-                    IsItemClickEnabled="True"
-                    SelectionMode="None"
-                    SingleSelectionFollowsFocus="False">
-            <i:Interaction.Behaviors>
-              <core:EventTriggerBehavior EventName="ItemClick">
-                <core:InvokeCommandAction Command="{Binding SearchHistoryItemCommand}"
-                                          InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-              </core:EventTriggerBehavior>
-            </i:Interaction.Behaviors>
-          </ListView>
+
+          <Frame x:Name="SearchResultFrame" CacheSize="0" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" DataContext="{x:Null}" />
+
         </toolkit:DockPanel>
-        <Grid x:Name="HeaderLayout" VerticalAlignment="Top" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-          <StackPanel>
-            <StackPanel Orientation="Horizontal" Height="48"></StackPanel>
-          </StackPanel>
-        </Grid>
+        
       </Grid>
     </Border>
     <VisualStateManager.VisualStateGroups>
@@ -187,35 +118,61 @@
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
-            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}" EqualTo="TV" />
+            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}">
+              <windowsStateTriggers:EqualsStateTrigger.EqualTo>
+                <appModels:ApplicationLayout>TV</appModels:ApplicationLayout>
+              </windowsStateTriggers:EqualsStateTrigger.EqualTo>
+            </windowsStateTriggers:EqualsStateTrigger>
           </VisualState.StateTriggers>
           <VisualState.Setters>
+            <Setter Target="ContentLayout.Margin" Value="0 32 0 0" />
             <Setter Target="ContentLayout.Padding" Value="{StaticResource ContentPageMargin_TV}" />
             <Setter Target="ContentLayout.MaxWidth" Value="1280" />
+            <Setter Target="SearchTargetListView.Margin" Value="0 0 0 8" />
           </VisualState.Setters>
         </VisualState>
         <VisualState>
           <VisualState.StateTriggers>
-            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}" EqualTo="Desktop" />
+            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}">
+              <windowsStateTriggers:EqualsStateTrigger.EqualTo>
+                <appModels:ApplicationLayout>Desktop</appModels:ApplicationLayout>
+              </windowsStateTriggers:EqualsStateTrigger.EqualTo>
+            </windowsStateTriggers:EqualsStateTrigger>
           </VisualState.StateTriggers>
           <VisualState.Setters>
+            <Setter Target="ContentLayout.Margin" Value="0 32 0 0" />
             <Setter Target="ContentLayout.Padding" Value="{StaticResource ContentPageMargin_Desktop}" />
+            <Setter Target="SearchTargetListView.Margin" Value="120 8 0 8" />
           </VisualState.Setters>
         </VisualState>
         <VisualState>
           <VisualState.StateTriggers>
-            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}" EqualTo="Tablet" />
+            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}">
+              <windowsStateTriggers:EqualsStateTrigger.EqualTo>
+                <appModels:ApplicationLayout>Tablet</appModels:ApplicationLayout>
+              </windowsStateTriggers:EqualsStateTrigger.EqualTo>
+            </windowsStateTriggers:EqualsStateTrigger>
           </VisualState.StateTriggers>
           <VisualState.Setters>
+            <!--
             <Setter Target="ContentLayout.Margin" Value="{StaticResource ContentPageMargin_Tablet}" />
+            -->
+            <Setter Target="SearchTargetListView.Margin" Value="0 8 0 8" />
           </VisualState.Setters>
         </VisualState>
         <VisualState>
           <VisualState.StateTriggers>
-            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}" EqualTo="Mobile" />
+            <windowsStateTriggers:EqualsStateTrigger Value="{Binding ApplicationLayoutManager.AppLayout}">
+              <windowsStateTriggers:EqualsStateTrigger.EqualTo>
+                <appModels:ApplicationLayout>Mobile</appModels:ApplicationLayout>
+              </windowsStateTriggers:EqualsStateTrigger.EqualTo>
+            </windowsStateTriggers:EqualsStateTrigger>
           </VisualState.StateTriggers>
           <VisualState.Setters>
+            <!--
             <Setter Target="ContentLayout.Margin" Value="{StaticResource ContentPageMargin_Mobile}" />
+            -->
+            <Setter Target="SearchTargetListView.Margin" Value="0 8 0 8" />
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml.cs
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Hohoema.Presentation.ViewModels.Pages.SearchPages;
+using Prism.Navigation;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,6 +14,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Prism.Ioc;
 
 // 空白ページの項目テンプレートについては、https://go.microsoft.com/fwlink/?LinkId=234238 を参照してください
 
@@ -22,9 +25,14 @@ namespace Hohoema.Presentation.Views.Pages.SearchPages
     /// </summary>
     public sealed partial class SearchPage : Page
     {
+        public static IPlatformNavigationService ContentNavigationService { get; private set; }
+        private readonly SearchPageViewModel _viewModel;
+
         public SearchPage()
         {
             this.InitializeComponent();
+
+            ContentNavigationService = NavigationService.Create(SearchResultFrame, new Gestures[] { });
         }
     }
 }

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultCommunityPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultCommunityPage.xaml
@@ -62,32 +62,6 @@
         <Grid x:Name="HeaderLayout" Background="{StaticResource MenuBackgroundBrush}">
           <uwpcontrols:ScrollHeader x:Name="ScrollHeader" Mode="Sticky">
             <StackPanel >
-              <ListView xmlns:ee="using:Hohoema.Models.Domain"
-                        SelectionMode="Single"
-                        IsItemClickEnabled="True"
-                        ItemsSource="{Binding SearchTargets}"
-                        SelectedItem="{Binding SelectedSearchTarget.Value, Mode=TwoWay}"
-                        Style="{StaticResource BandListViewStyle}"
-                        ItemContainerStyle="{StaticResource SimpleListViewItemStyle}"
-                        SingleSelectionFollowsFocus="False"
-                        HorizontalAlignment="Right">
-                <i:Interaction.Behaviors>
-                  <core:EventTriggerBehavior EventName="ItemClick">
-                    <core:InvokeCommandAction Command="{Binding ChangeSearchTargetCommand}"
-                                              InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-                  </core:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-                <ListView.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                  </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-              </ListView>
               <CommandBar>
                 <CommandBar.PrimaryCommands>
                   <AppBarButton x:Name="ScrollToTopButton" Label="{Binding Source=ReturnToPageTop, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Icon="Up">
@@ -100,49 +74,13 @@
                   <AppBarButton Background="Transparent" Label="{Binding Source=Refresh, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Command="{Binding RefreshCommand}"  Icon="Refresh" />
                 </CommandBar.PrimaryCommands>
                 <CommandBar.Content>
-                  <toolkit:DockPanel Margin="16 0 0 0" x:Name="TitleLayout">
-                    <HyperlinkButton Command="{Binding PageManager.OpenPageCommand}" CommandParameter="Search" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Margin="0 0 16 0" toolkit:DockPanel.Dock="Left" VerticalAlignment="Stretch">
-                      <SymbolIcon Symbol="Find" />
-                    </HyperlinkButton>
-                    <HyperlinkButton toolkit:DockPanel.Dock="Left" Margin="8 0">
-                      <i:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Click">
-                          <mybehavior:OpenFlyout />
-                        </core:EventTriggerBehavior>
-                      </i:Interaction.Behaviors>
-                      <TextBlock Text="{Binding SearchOptionText}" Style="{StaticResource CaptionTextBlockStyle}"></TextBlock>
-                      <FlyoutBase.AttachedFlyout>
-                        <Flyout>
-                          <StackPanel MaxWidth="300">
-                            <ListView ItemsSource="{Binding CommunitySearchSortOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-                              <ListView.ItemContainerStyle>
-                                <Style TargetType="ListViewItem">
-                                  <Setter Property="Width" Value="140" />
-                                </Style>
-                              </ListView.ItemContainerStyle>
-                              <ListView.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                  <ItemsWrapGrid Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                              </ListView.ItemsPanel>
-                            </ListView>
-                            <ListView ItemsSource="{Binding CommunitySearchModeOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchMode.Value, Mode=TwoWay}" Margin="0 16 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-                              <ListView.ItemContainerStyle>
-                                <Style TargetType="ListViewItem">
-                                  <Setter Property="Width" Value="140" />
-                                </Style>
-                              </ListView.ItemContainerStyle>
-                              <ListView.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                  <ItemsWrapGrid Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                              </ListView.ItemsPanel>
-                            </ListView>
-                          </StackPanel>
-                        </Flyout>
-                      </FlyoutBase.AttachedFlyout>
-                    </HyperlinkButton>
-                    <Border />
+                  <toolkit:DockPanel Margin="0 0 0 0" x:Name="TitleLayout">
+                    <StackPanel Orientation="Horizontal">
+                      <ComboBox ItemsSource="{Binding CommunitySearchSortOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" >
+                      </ComboBox>
+                      <ComboBox ItemsSource="{Binding CommunitySearchModeOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchMode.Value, Mode=TwoWay}" Margin="0 16 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                      </ComboBox>
+                    </StackPanel>
                   </toolkit:DockPanel>
                 </CommandBar.Content>
               </CommandBar>
@@ -177,6 +115,7 @@
         </VisualState>
       </VisualStateGroup>
       <!-- レイアウトモード -->
+      <!--
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
@@ -215,6 +154,7 @@
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
+      -->
     </VisualStateManager.VisualStateGroups>
   </Grid>
 </Page>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultKeywordPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultKeywordPage.xaml
@@ -37,34 +37,8 @@
     <videolistPage:VideoItemsListView ItemsSource="{Binding ItemsView}" ItemCommand="{Binding HohoemaPlaylist.PlayCommand}" ItemContextFlyoutTemplate="{StaticResource VideoListItemFlyoutTemplate}" RefreshCommand="{Binding RefreshCommand}" x:Name="VideoItemsListView">
       <videolistPage:VideoItemsListView.Header>
         <Grid x:Name="HeaderLayout" Background="{StaticResource MenuBackgroundBrush}">
-          <controls:ScrollHeader x:Name="ScrollHeader" Mode="Sticky">
+          <controls:ScrollHeader x:Name="ScrollHeader" Mode="Sticky" IsTabStop="False">
             <StackPanel >
-              <ListView xmlns:ee="using:Hohoema.Models.Domain"
-                        SelectionMode="Single"
-                        IsItemClickEnabled="True"
-                        ItemsSource="{Binding SearchTargets}"
-                        SelectedItem="{Binding SelectedSearchTarget.Value, Mode=TwoWay}"
-                        Style="{StaticResource BandListViewStyle}"
-                        ItemContainerStyle="{StaticResource SimpleListViewItemStyle}"
-                        SingleSelectionFollowsFocus="False"
-                        HorizontalAlignment="Right">
-                <i:Interaction.Behaviors>
-                  <core:EventTriggerBehavior EventName="ItemClick">
-                    <core:InvokeCommandAction Command="{Binding ChangeSearchTargetCommand}"
-                                              InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-                  </core:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-                <ListView.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                  </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-              </ListView>
               <CommandBar>
                 <CommandBar.PrimaryCommands>
 
@@ -87,38 +61,12 @@
                   </AppBarButton>
                 </CommandBar.SecondaryCommands>
                 <CommandBar.Content>
-                  <toolkit:DockPanel x:Name="TitleLayout" Margin="16 0 0 0">
-                    <HyperlinkButton Command="{Binding PageManager.OpenPageCommand}" CommandParameter="Search" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Margin="0 0 16 0" toolkit:DockPanel.Dock="Left" VerticalAlignment="Stretch">
-                      <SymbolIcon Symbol="Find" />
-                    </HyperlinkButton>
-                    <StackPanel>
-                      <HyperlinkButton toolkit:DockPanel.Dock="Bottom">
-                        <i:Interaction.Behaviors>
-                          <core:EventTriggerBehavior EventName="Click">
-                            <mybehavior:OpenFlyout />
-                          </core:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                        <TextBlock Text="{Binding SearchOptionText}" Style="{StaticResource CaptionTextBlockStyle}" />
-                        <FlyoutBase.AttachedFlyout>
-                          <Flyout>
-                            <StackPanel MaxWidth="300">
-                              <ListView ItemsSource="{Binding VideoSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-                                <ListView.ItemContainerStyle>
-                                  <Style TargetType="ListViewItem">
-                                    <Setter Property="Width" Value="140" />
-                                  </Style>
-                                </ListView.ItemContainerStyle>
-                                <ListView.ItemsPanel>
-                                  <ItemsPanelTemplate>
-                                    <ItemsWrapGrid Orientation="Horizontal" />
-                                  </ItemsPanelTemplate>
-                                </ListView.ItemsPanel>
-                              </ListView>
-                            </StackPanel>
-                          </Flyout>
-                        </FlyoutBase.AttachedFlyout>
-                      </HyperlinkButton>
-                    </StackPanel>
+                  <toolkit:DockPanel x:Name="TitleLayout" Margin="0 0 0 0">
+                    <ComboBox ItemsSource="{Binding VideoSearchOptionListItems}" 
+                                DisplayMemberPath="Label" 
+                                SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" 
+                                Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                    </ComboBox>
                   </toolkit:DockPanel>
                 </CommandBar.Content>
               </CommandBar>
@@ -150,6 +98,7 @@
     </Grid>
     <VisualStateManager.VisualStateGroups>
       <!-- レイアウトモード -->
+      <!--
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
@@ -188,7 +137,7 @@
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
-      
+      -->
       
       <VisualStateGroup>
         <VisualState>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultLivePage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultLivePage.xaml
@@ -64,33 +64,7 @@
         <Grid x:Name="HeaderLayout" Background="{StaticResource MenuBackgroundBrush}">
           <controls:ScrollHeader x:Name="ScrollHeader" Mode="Sticky">
             <StackPanel>
-              <ListView xmlns:ee="using:Hohoema.Models.Domain"
-                        SelectionMode="Single"
-                        IsItemClickEnabled="True"
-                        ItemsSource="{Binding SearchTargets}"
-                        SelectedItem="{Binding SelectedSearchTarget.Value, Mode=TwoWay}"
-                        Style="{StaticResource BandListViewStyle}"
-                        ItemContainerStyle="{StaticResource SimpleListViewItemStyle}"
-                        SingleSelectionFollowsFocus="False"
-                        HorizontalAlignment="Right">
-                <i:Interaction.Behaviors>
-                  <core:EventTriggerBehavior EventName="ItemClick">
-                    <core:InvokeCommandAction Command="{Binding ChangeSearchTargetCommand}"
-                                              InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-                  </core:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-                <ListView.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                  </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-              </ListView>
-              <CommandBar toolkit:DockPanel.Dock="Right" Margin="8 0">
+              <CommandBar toolkit:DockPanel.Dock="Right" Margin="0">
                 <CommandBar.PrimaryCommands>
                   <AppBarButton x:Name="ScrollToTopButton" Label="{Binding Source=ReturnToPageTop, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Icon="Up">
                     <i:Interaction.Behaviors>
@@ -102,11 +76,8 @@
                   <AppBarButton Background="Transparent" Label="{Binding Source=Refresh, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Command="{Binding RefreshCommand}" Icon="Refresh" />
                 </CommandBar.PrimaryCommands>
                 <CommandBar.Content>
-                  <Border Margin="16 0 0 0" x:Name="TitleLayout">
+                  <Border Margin="0 0 0 0" x:Name="TitleLayout">
                     <toolkit:DockPanel VerticalAlignment="Center">
-                      <HyperlinkButton Command="{Binding PageManager.OpenPageCommand}" CommandParameter="Search" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Margin="0 0 16 0" toolkit:DockPanel.Dock="Left" VerticalAlignment="Stretch">
-                        <SymbolIcon Symbol="Find" />
-                      </HyperlinkButton>
                       <uwpcontrols:WrapPanel Orientation="Horizontal">
                         <!-- LiveStatus -->
                         <ListView ItemsSource="{Binding LiveSearchLiveStatusListItems}" 
@@ -168,6 +139,7 @@
     </ListView>
     <VisualStateManager.VisualStateGroups>
       <!-- レイアウトモード -->
+      <!--
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
@@ -206,6 +178,7 @@
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
+      -->
       
     </VisualStateManager.VisualStateGroups>
   </Grid>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultMylistPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultMylistPage.xaml
@@ -40,7 +40,7 @@
               UseSystemFocusVisuals="True"
               SelectionMode="None"
               HorizontalContentAlignment="Stretch"
-              Padding="16 0"
+              Padding="0 0"
               uwpExtensions:ScrollViewerExtensions.VerticalScrollBarMargin="0 96 0 0">
       <GridView.ItemContainerTransitions>
         <TransitionCollection></TransitionCollection>
@@ -65,31 +65,6 @@
         <Grid x:Name="HeaderLayout" Background="{StaticResource MenuBackgroundBrush}">
           <controls:ScrollHeader x:Name="ScrollHeader" Mode="Sticky">
             <StackPanel>
-              <ListView xmlns:ee="using:Hohoema.Models.Domain"
-                        SelectionMode="Single"
-                        IsItemClickEnabled="True"
-                        ItemsSource="{Binding SearchTargets}"
-                        SelectedItem="{Binding SelectedSearchTarget.Value, Mode=TwoWay}"
-                        Style="{StaticResource BandListViewStyle}"
-                        ItemContainerStyle="{StaticResource SimpleListViewItemStyle}"
-                        HorizontalAlignment="Right">
-                <i:Interaction.Behaviors>
-                  <core:EventTriggerBehavior EventName="ItemClick">
-                    <core:InvokeCommandAction Command="{Binding ChangeSearchTargetCommand}"
-                                              InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-                  </core:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-                <ListView.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                  </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-              </ListView>
               <CommandBar>
                 <CommandBar.PrimaryCommands>
                   <AppBarButton x:Name="ScrollToTopButton" Label="{Binding Source=ReturnToPageTop, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Icon="Up">
@@ -102,43 +77,9 @@
                   <AppBarButton Background="Transparent" Label="{Binding Source=Refresh, Converter={StaticResource LocalizeConverter}, Mode=OneTime}" Command="{Binding RefreshCommand}" Icon="Refresh" />
                 </CommandBar.PrimaryCommands>
                 <CommandBar.Content>
-                  <toolkit:DockPanel x:Name="TitleLayout" Margin="16 0 0 0">
-                    <HyperlinkButton Command="{Binding PageManager.OpenPageCommand}" CommandParameter="Search" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Margin="0 0 16 0" toolkit:DockPanel.Dock="Left" VerticalAlignment="Stretch" Height="48">
-                      <SymbolIcon Symbol="Find" />
-                    </HyperlinkButton>
-                    <HyperlinkButton toolkit:DockPanel.Dock="Left" Margin="8 0">
-                      <i:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Click">
-                          <mybehavior:OpenFlyout />
-                        </core:EventTriggerBehavior>
-                      </i:Interaction.Behaviors>
-                      <TextBlock Text="{Binding SearchOptionText}" Style="{StaticResource CaptionTextBlockStyle}"></TextBlock>
-                      <FlyoutBase.AttachedFlyout>
-                        <Flyout>
-                          <StackPanel MaxWidth="300">
-                            <ListView ItemsSource="{Binding MylistSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-                              <ListView.ItemContainerStyle>
-                                <Style TargetType="ListViewItem">
-                                  <Setter Property="Width" Value="140" />
-                                </Style>
-                              </ListView.ItemContainerStyle>
-                              <ListView.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                  <ItemsWrapGrid Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                              </ListView.ItemsPanel>
-                            </ListView>
-                          </StackPanel>
-                        </Flyout>
-                      </FlyoutBase.AttachedFlyout>
-                    </HyperlinkButton>
-                    <StackPanel Background="Transparent" IsHitTestVisible="True">
-                      <i:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Tapped">
-                          <core:ChangePropertyAction TargetObject="{Binding}" PropertyName="ListPosition" Value="0.0" />
-                        </core:EventTriggerBehavior>
-                      </i:Interaction.Behaviors>
-                    </StackPanel>
+                  <toolkit:DockPanel x:Name="TitleLayout" Margin="0 0 0 0">
+                    <ComboBox ItemsSource="{Binding MylistSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                    </ComboBox>
                   </toolkit:DockPanel>
                 </CommandBar.Content>
               </CommandBar>
@@ -154,6 +95,7 @@
     </GridView>
     <VisualStateManager.VisualStateGroups>
       <!-- レイアウトモード -->
+      <!--
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
@@ -192,6 +134,7 @@
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
+      -->
       
     </VisualStateManager.VisualStateGroups>
   </Grid>

--- a/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultTagPage.xaml
+++ b/Hohoema/Presentation.Views.Pages/SearchPages/SearchResultTagPage.xaml
@@ -38,32 +38,6 @@
         <Grid x:Name="HeaderLayout" Background="{StaticResource MenuBackgroundBrush}">
           <controls:ScrollHeader x:Name="ScrollHeader" Mode="Sticky">
             <StackPanel >
-              <ListView xmlns:ee="using:Hohoema.Models.Domain"
-                        SelectionMode="Single"
-                        IsItemClickEnabled="True"
-                        ItemsSource="{Binding SearchTargets}"
-                        SelectedItem="{Binding SelectedSearchTarget.Value, Mode=TwoWay}"
-                        Style="{StaticResource BandListViewStyle}"
-                        ItemContainerStyle="{StaticResource SimpleListViewItemStyle}"
-                        SingleSelectionFollowsFocus="False"
-                        HorizontalAlignment="Right">
-                <i:Interaction.Behaviors>
-                  <core:EventTriggerBehavior EventName="ItemClick">
-                    <core:InvokeCommandAction Command="{Binding ChangeSearchTargetCommand}"
-                                              InputConverter="{StaticResource ItemClickEventArgsConverter}" />
-                  </core:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}}" />
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-                <ListView.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                  </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-              </ListView>
               <CommandBar>
                 <CommandBar.PrimaryCommands>
 
@@ -87,38 +61,12 @@
                   </AppBarButton>
                 </CommandBar.SecondaryCommands>
                 <CommandBar.Content>
-                  <toolkit:DockPanel x:Name="TitleLayout" Margin="16 0 0 0">
-                    <HyperlinkButton Command="{Binding PageManager.OpenPageCommand}" CommandParameter="Search" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Margin="0 0 16 0" toolkit:DockPanel.Dock="Left" VerticalAlignment="Stretch">
-                      <SymbolIcon Symbol="Find" />
-                    </HyperlinkButton>
-                    <StackPanel>
-                      <HyperlinkButton toolkit:DockPanel.Dock="Bottom">
-                        <i:Interaction.Behaviors>
-                          <core:EventTriggerBehavior EventName="Click">
-                            <mybehavior:OpenFlyout />
-                          </core:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                        <TextBlock Text="{Binding SearchOptionText}" Style="{StaticResource CaptionTextBlockStyle}" />
-                        <FlyoutBase.AttachedFlyout>
-                          <Flyout>
-                            <StackPanel MaxWidth="300">
-                              <ListView ItemsSource="{Binding VideoSearchOptionListItems}" DisplayMemberPath="Label" SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionMode="Single" SingleSelectionFollowsFocus="False">
-                                <ListView.ItemContainerStyle>
-                                  <Style TargetType="ListViewItem">
-                                    <Setter Property="Width" Value="140" />
-                                  </Style>
-                                </ListView.ItemContainerStyle>
-                                <ListView.ItemsPanel>
-                                  <ItemsPanelTemplate>
-                                    <ItemsWrapGrid Orientation="Horizontal" />
-                                  </ItemsPanelTemplate>
-                                </ListView.ItemsPanel>
-                              </ListView>
-                            </StackPanel>
-                          </Flyout>
-                        </FlyoutBase.AttachedFlyout>
-                      </HyperlinkButton>
-                    </StackPanel>
+                  <toolkit:DockPanel x:Name="TitleLayout" Margin="0 0 0 0">
+                    <ComboBox ItemsSource="{Binding VideoSearchOptionListItems}" 
+                                DisplayMemberPath="Label" 
+                                SelectedItem="{Binding SelectedSearchSort.Value, Mode=TwoWay}" 
+                                Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                    </ComboBox>
                   </toolkit:DockPanel>
                 </CommandBar.Content>
               </CommandBar>
@@ -161,6 +109,7 @@
         </VisualState>
       </VisualStateGroup>
       <!-- レイアウトモード -->
+      <!--
       <VisualStateGroup>
         <VisualState>
           <VisualState.StateTriggers>
@@ -199,6 +148,7 @@
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
+      -->
       
       <VisualStateGroup>
         <VisualState>

--- a/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml
+++ b/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml
@@ -723,22 +723,9 @@
                       Width="13" />
         </Button>
       </Border>
-      
+
       <StackPanel x:Name="DebugUIPanel" Orientation="Horizontal" Visibility="Collapsed" HorizontalAlignment="Right" Margin="0 0 140 0" Spacing="8" Opacity="0.8">
-        <TextBlock Text="{x:Bind _viewModel.ApplicationLayoutManager.AppLayout, Mode=OneWay}" FontSize="9" VerticalAlignment="Center" />
-        <StackPanel>
-          <TextBlock Text="レイアウト"
-                     VerticalAlignment="Center"
-                     FontSize="9" />
-          <winui:ComboBox ItemsSource="{x:Bind IntaractionModeList}" SelectedItem="{Binding AppearanceSettings.OverrideInteractionMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" FontSize="9" MinHeight="14" Height="20" Padding="3"
-                          >
-            <winui:ComboBox.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Text="{Binding Converter={StaticResource LocalizeConverter}, FallbackValue={Binding Source=NoSelected, Converter={StaticResource LocalizeConverter}}}" />
-              </DataTemplate>
-            </winui:ComboBox.ItemTemplate>
-          </winui:ComboBox>
-        </StackPanel>
+        
       </StackPanel>
       
     </Grid>

--- a/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml
+++ b/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml
@@ -431,7 +431,13 @@
             </uwpToolkitControls:DockPanel>
             <!-- Search Box -->
             <Border uwpToolkitControls:DockPanel.Dock="Top">
-              <TextBox x:Name="SearchTextBox" Text="{x:Bind SearchInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="{Binding Source=Search, Converter={StaticResource LocalizeConverter}}" UseSystemFocusVisuals="True" TabIndex="103" Margin="8" IsFocusEngagementEnabled="True" >
+              <AutoSuggestBox x:Name="SearchTextBox" Text="{x:Bind SearchInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="{Binding Source=Search, Converter={StaticResource LocalizeConverter}}" UseSystemFocusVisuals="True" TabIndex="103" Margin="8" IsFocusEngagementEnabled="True" 
+                              ItemsSource="{Binding SearchAutoSuggestItems}"
+                              QuerySubmitted="SearchTextBox_QuerySubmitted"
+                              TextChanged="SearchTextBox_TextChanged"
+                              UpdateTextOnSelect="False"
+                              GotFocus="SearchTextBox_GotFocus"
+                              >
                 <i:Interaction.Behaviors>
                   <core:EventTriggerBehavior EventName="GotFocus">
                     <core:CallMethodAction MethodName="SelectAll" />
@@ -440,7 +446,13 @@
                     <core:InvokeCommandAction Command="{Binding SearchCommand}" CommandParameter="{x:Bind SearchInputText, Mode=OneWay}" />
                   </mybehavior:KeyboardTrigger>
                 </i:Interaction.Behaviors>
-              </TextBox>
+
+                <AutoSuggestBox.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding Id, Converter={StaticResource LocalizeConverter}}" />
+                  </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+              </AutoSuggestBox>
             </Border>
 
             <Border x:Name="TV_OpenSearchPageButton" Visibility="Collapsed" uwpToolkitControls:DockPanel.Dock="Top">
@@ -610,7 +622,15 @@
                   </core:EventTriggerBehavior>
                 </i:Interaction.Behaviors>
               </Border>
-              <TextBox x:Name="Mobile_SearchTextBox" Text="{x:Bind SearchInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="{Binding Source=Search, Converter={StaticResource LocalizeConverter}}" UseSystemFocusVisuals="True" TabIndex="103" Visibility="Collapsed" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="120 0 32 0">
+              <AutoSuggestBox x:Name="Mobile_SearchTextBox" Text="{x:Bind SearchInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                              PlaceholderText="{Binding Source=Search, Converter={StaticResource LocalizeConverter}}" UseSystemFocusVisuals="True" 
+                              TabIndex="103" Visibility="Collapsed" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="120 0 32 0"
+                              ItemsSource="{Binding SearchAutoSuggestItems}"
+                              QuerySubmitted="SearchTextBox_QuerySubmitted"
+                              TextChanged="SearchTextBox_TextChanged"
+                              UpdateTextOnSelect="False"
+                              GotFocus="SearchTextBox_GotFocus"
+                              >
                 <i:Interaction.Behaviors>
                   <core:EventTriggerBehavior EventName="GotFocus">
                     <core:CallMethodAction MethodName="SelectAll" />
@@ -623,7 +643,12 @@
                     <core:ChangePropertyAction TargetObject="{x:Bind}" PropertyName="NowMobileSearchTextInput" Value="False" />
                   </mybehavior:KeyboardTrigger>
                 </i:Interaction.Behaviors>
-              </TextBox>
+                <AutoSuggestBox.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding Id, Converter={StaticResource LocalizeConverter}}" />
+                  </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+              </AutoSuggestBox>
             </Grid>
             <Grid x:Name="MenuBackgroundGrid"
                   Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"

--- a/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml.cs
+++ b/Hohoema/Presentation.Views/PrimaryViewCoreLayout.xaml.cs
@@ -41,6 +41,7 @@ using Hohoema.Models.Domain.Application;
 using Microsoft.AppCenter.Analytics;
 using System.Text;
 using Microsoft.AppCenter.Crashes;
+using System.Windows.Input;
 
 // ユーザー コントロールの項目テンプレートについては、https://go.microsoft.com/fwlink/?LinkId=234236 を参照してください
 
@@ -803,6 +804,28 @@ namespace Hohoema.Presentation.Views
 
 
 
+        private void SearchTextBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            sender.IsSuggestionListOpen = !string.IsNullOrWhiteSpace(sender.Text);
+        }
+
+        private void SearchTextBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            if (args.ChosenSuggestion is SearchAutoSuggestItemViewModel tag)
+            {
+                tag.SearchAction(args.QueryText);
+            }
+            else
+            {
+                (_viewModel.SearchCommand as ICommand).Execute(args.QueryText);
+            }
+        }
+
+        private void SearchTextBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            var asb = (sender as AutoSuggestBox);
+            asb.IsSuggestionListOpen = !string.IsNullOrWhiteSpace(asb.Text);
+        }
     }
 
     public static class NavigationParametersExtensions


### PR DESCRIPTION
### 課題

検索ページ内に検索テキストボックスが無く「再検索がしづらいUI」を解決したい。

### 変更内容

検索の共通UIを検索ページ上に配置した上で、検索ページ内の子ページとして検索結果ページを表示する構造に変更。

* ページ名解決として表では全てSearchPageに対するものに修正した。
* 検索ページ内の子ページとして検索結果ページの解決を行う。キーワード検索、タグ検索などの切り替えは検索ページへのserviceパラメータを使って表示を切り替えている。
* ページ構造の変化に伴い、ピン留め機能のページ名及びページパラメータを修正する統合処理を追加。また、SearchPageのピン留め対応を追加。